### PR TITLE
Hotfix/wrong token count

### DIFF
--- a/crypto/src/main/java/org/cryptimeleon/incentive/crypto/Helper.java
+++ b/crypto/src/main/java/org/cryptimeleon/incentive/crypto/Helper.java
@@ -95,14 +95,15 @@ public class Helper {
     ) {
         var spendRequest = incSys.generateSpendRequest(promP, token, pkp.getPk(), newPoints, ukp, tid, spendDeductTree);
 
-        var deductOutput = incSys.generateSpendRequestResponse(promP, spendRequest, pkp, tid, spendDeductTree);
+        // using tid as user choice TODO change this once user choice generation is properly implemented, see issue 75
+        var deductOutput = incSys.generateSpendRequestResponse(promP, spendRequest, pkp, tid, spendDeductTree, tid);
 
         var resultToken = incSys.handleSpendRequestResponse(promP, deductOutput.getSpendResponse(), spendRequest, token, newPoints, pkp.getPk(), ukp);
 
         var occuredTransaction = new Transaction(
                 true,
                 tid,
-                token.getPoints().get(0).asInteger().subtract(newPoints.get(0)), // for v1: difference in 0-th component taken as spend amount TODO make transaction API able to handle vectors
+                token.getPoints().get(0).asInteger().subtract(newPoints.get(0)), // for v1: difference in 0-th component taken as spend amount TODO adapt transaction API to new Spend-Deduct API
                 deductOutput.getDstag()
         );
 

--- a/crypto/src/main/java/org/cryptimeleon/incentive/crypto/IncentiveSystem.java
+++ b/crypto/src/main/java/org/cryptimeleon/incentive/crypto/IncentiveSystem.java
@@ -475,7 +475,7 @@ public class IncentiveSystem {
         var spendDeductZkp = new SpendDeductBooleanZkp(spendDeductTree, pp, promotionParameters, providerKeyPair.getPk());
         var fiatShamirProofSystem = new FiatShamirProofSystem(spendDeductZkp);
         // using tid as user choice TODO change this once user choice generation is properly implemented, see issue 75
-        var gamma = Util.hashGamma(pp.getBg().getZn(), spendRequest.getDsid(), tid, spendRequest.getCPre0(), spendRequest.getCPre1(), tid);
+        var gamma = Util.hashGamma(pp.getBg().getZn(), spendRequest.getDsid(), tid, spendRequest.getCPre0(), spendRequest.getCPre1(), userChoice);
         var commonInput = new SpendDeductZkpCommonInput(spendRequest, gamma);
         var proofValid = fiatShamirProofSystem.checkProof(commonInput, spendRequest.getSpendDeductZkp());
         if (!proofValid) {

--- a/crypto/src/main/java/org/cryptimeleon/incentive/crypto/IncentiveSystem.java
+++ b/crypto/src/main/java/org/cryptimeleon/incentive/crypto/IncentiveSystem.java
@@ -474,11 +474,19 @@ public class IncentiveSystem {
             throw new IllegalArgumentException("ZKP of the request is not valid!");
         }
 
-        /* Request is valid. Compute new blinded token and signature */
-        // Retrieve esk^*_prov via PRF
+        /* Request is valid. Compute new blinded token and signature
+        *
+        * Retrieve esk*_prov via PRF.
+        * Need to use double-spending ID of the spent token as well as the transaction ID in addition to preliminary commitment as input for the PRF
+        * to ensure that different spendings of the same token lead to different esk_prov.
+        * Also need to include object modelling the reward that the user chose to claim.
+        */
         var preimage = new ByteArrayAccumulator();
         preimage.escapeAndSeparate(commonInput.c0Pre);
         preimage.escapeAndSeparate(commonInput.c1Pre);
+        preimage.escapeAndSeparate(spendRequest.getDsid());
+        preimage.escapeAndSeparate(tid);
+
         var eskStarProv = pp.getPrfToZn().hashThenPrfToZn(providerKeyPair.getSk().getBetaProv(), new ByteArrayImplementation(preimage.extractBytes()), "eskStarProv");
 
         // Compute blind signature on new, still blinded commitment

--- a/crypto/src/main/java/org/cryptimeleon/incentive/crypto/Util.java
+++ b/crypto/src/main/java/org/cryptimeleon/incentive/crypto/Util.java
@@ -1,5 +1,6 @@
 package org.cryptimeleon.incentive.crypto;
 
+import org.cryptimeleon.math.hash.UniqueByteRepresentable;
 import org.cryptimeleon.math.hash.impl.ByteArrayAccumulator;
 import org.cryptimeleon.math.structures.cartesian.Vector;
 import org.cryptimeleon.math.structures.groups.GroupElement;
@@ -24,13 +25,14 @@ public class Util {
      * @param cPre1 cPre1 to hash
      * @return hashed ZnElement gamma
      */
-    public static Zn.ZnElement hashGamma(Zn zn, GroupElement dsid, Zn.ZnElement tid, GroupElement cPre0, GroupElement cPre1) {
+    public static Zn.ZnElement hashGamma(Zn zn, GroupElement dsid, Zn.ZnElement tid, GroupElement cPre0, GroupElement cPre1, UniqueByteRepresentable userChoice) {
         var hashfunction = new HashIntoZn(zn);
         var accumulator = new ByteArrayAccumulator();
         accumulator.escapeAndSeparate(dsid.getUniqueByteRepresentation());
         accumulator.escapeAndSeparate(tid.getUniqueByteRepresentation());
         accumulator.escapeAndSeparate(cPre0.getUniqueByteRepresentation());
         accumulator.escapeAndSeparate(cPre1.getUniqueByteRepresentation());
+        accumulator.escapeAndSeparate(userChoice);
         return hashfunction.hash(accumulator.extractBytes());
     }
 

--- a/crypto/src/main/java/org/cryptimeleon/incentive/crypto/benchmark/Benchmark.java
+++ b/crypto/src/main/java/org/cryptimeleon/incentive/crypto/benchmark/Benchmark.java
@@ -180,7 +180,8 @@ public class Benchmark {
                     spendRequest,
                     providerKeyPair,
                     tid,
-                    spendDeductTree
+                    spendDeductTree,
+                    tid // using tid as user choice TODO change this once user choice generation is properly implemented, see issue 75
             );
             finish = Instant.now();
             tSpendResponse[i] = Duration.between(start, finish).toNanos();

--- a/crypto/src/main/java/org/cryptimeleon/incentive/crypto/dsprotectionlogic/DatabaseHandler.java
+++ b/crypto/src/main/java/org/cryptimeleon/incentive/crypto/dsprotectionlogic/DatabaseHandler.java
@@ -116,7 +116,7 @@ public interface DatabaseHandler {
     long getTransactionCount();
 
     long getTokenCount();
-
+    
     long getDsTagCount();
 
     long getUserInfoCount();

--- a/crypto/src/main/java/org/cryptimeleon/incentive/crypto/model/SpendRequest.java
+++ b/crypto/src/main/java/org/cryptimeleon/incentive/crypto/model/SpendRequest.java
@@ -8,6 +8,7 @@ import org.cryptimeleon.craco.protocols.arguments.fiatshamir.FiatShamirProofSyst
 import org.cryptimeleon.craco.sig.sps.eq.SPSEQSignature;
 import org.cryptimeleon.incentive.crypto.Util;
 import org.cryptimeleon.incentive.crypto.proof.spend.zkp.SpendDeductZkpCommonInput;
+import org.cryptimeleon.math.hash.UniqueByteRepresentable;
 import org.cryptimeleon.math.serialization.ListRepresentation;
 import org.cryptimeleon.math.serialization.Representable;
 import org.cryptimeleon.math.serialization.Representation;
@@ -61,7 +62,7 @@ public class SpendRequest implements Representable {
      * @param fiatShamirProofSystem the fiat shamir proof system used to create the proof to be restored
      * @param tid                   the transaction id
      */
-    public SpendRequest(Representation repr, IncentivePublicParameters pp, FiatShamirProofSystem fiatShamirProofSystem, Zn.ZnElement tid) {
+    public SpendRequest(Representation repr, IncentivePublicParameters pp, FiatShamirProofSystem fiatShamirProofSystem, Zn.ZnElement tid, UniqueByteRepresentable userChoice) {
         var listRepr = repr.list();
         var zn = pp.getBg().getZn();
         var groupG1 = pp.getBg().getG1();
@@ -77,7 +78,7 @@ public class SpendRequest implements Representable {
         this.cTrace1 = groupG1.restoreVector(listRepr.get(7));
 
         // using tid as user choice TODO change this once user choice generation is properly implemented, see issue 75
-        var gamma = Util.hashGamma(zn, dsid, tid, cPre0, cPre1, tid);
+        var gamma = Util.hashGamma(zn, dsid, tid, cPre0, cPre1, userChoice);
         var spendDeductCommonInput = new SpendDeductZkpCommonInput(gamma, c0, c1, dsid, cPre0, cPre1, commitmentC0, cTrace0, cTrace1);
         this.spendDeductZkp = fiatShamirProofSystem.restoreProof(spendDeductCommonInput, listRepr.get(8));
         this.sigma = new SPSEQSignature(listRepr.get(9), groupG1, groupG2);

--- a/crypto/src/main/java/org/cryptimeleon/incentive/crypto/model/SpendRequest.java
+++ b/crypto/src/main/java/org/cryptimeleon/incentive/crypto/model/SpendRequest.java
@@ -51,6 +51,7 @@ public class SpendRequest implements Representable {
     @NonFinal
     SPSEQSignature sigma;
 
+
     /**
      * A constructor for the spend request based on a representation and additional data required to retrieve the
      * original values.
@@ -75,7 +76,8 @@ public class SpendRequest implements Representable {
         this.cTrace0 = groupG1.restoreVector(listRepr.get(6));
         this.cTrace1 = groupG1.restoreVector(listRepr.get(7));
 
-        var gamma = Util.hashGamma(zn, dsid, tid, cPre0, cPre1);
+        // using tid as user choice TODO change this once user choice generation is properly implemented, see issue 75
+        var gamma = Util.hashGamma(zn, dsid, tid, cPre0, cPre1, tid);
         var spendDeductCommonInput = new SpendDeductZkpCommonInput(gamma, c0, c1, dsid, cPre0, cPre1, commitmentC0, cTrace0, cTrace1);
         this.spendDeductZkp = fiatShamirProofSystem.restoreProof(spendDeductCommonInput, listRepr.get(8));
         this.sigma = new SPSEQSignature(listRepr.get(9), groupG1, groupG2);

--- a/crypto/src/main/java/org/cryptimeleon/incentive/crypto/proof/spend/tree/SpendDeductTree.java
+++ b/crypto/src/main/java/org/cryptimeleon/incentive/crypto/proof/spend/tree/SpendDeductTree.java
@@ -1,5 +1,6 @@
 package org.cryptimeleon.incentive.crypto.proof.spend.tree;
 
+import org.cryptimeleon.math.hash.UniqueByteRepresentable;
 import org.cryptimeleon.math.structures.cartesian.Vector;
 
 import java.math.BigInteger;

--- a/crypto/src/main/java/org/cryptimeleon/incentive/crypto/proof/spend/tree/SpendDeductTree.java
+++ b/crypto/src/main/java/org/cryptimeleon/incentive/crypto/proof/spend/tree/SpendDeductTree.java
@@ -1,6 +1,5 @@
 package org.cryptimeleon.incentive.crypto.proof.spend.tree;
 
-import org.cryptimeleon.math.hash.UniqueByteRepresentable;
 import org.cryptimeleon.math.structures.cartesian.Vector;
 
 import java.math.BigInteger;

--- a/crypto/src/test/java/org/cryptimeleon/incentive/crypto/IncentiveSystemTest.java
+++ b/crypto/src/test/java/org/cryptimeleon/incentive/crypto/IncentiveSystemTest.java
@@ -131,6 +131,7 @@ public class IncentiveSystemTest {
          * transaction 3: user tries to spend 23 points
          *
          * TODO add token condition proof for testing this
+         * TODO after doing so, add hashedClaim PRFtoZn value as discussed in issue #75
 
         logger.info("Testing failing spend transaction with non-empty token.");
 
@@ -179,7 +180,8 @@ public class IncentiveSystemTest {
         var deserializedSpendRequest3 = new SpendRequest(serializedSpendRequest3, incSys.getPp(), spendDeductProofSystem, tid3);
 
         // provider handles spend request and generates spend response and information required for double-spending protection (which is discarded on the fly, since not needed in this test)
-        var spendResponse3 = incSys.generateSpendRequestResponse(promotionParameters, deserializedSpendRequest3, pkp, tid3, spendDeductTestZkp).getSpendResponse();
+        // using tid as user choice TODO change this once user choice generation is properly implemented, see issue 75
+        var spendResponse3 = incSys.generateSpendRequestResponse(promotionParameters, deserializedSpendRequest3, pkp, tid3, spendDeductTestZkp, tid3).getSpendResponse();
 
         // serialize and deserialize spend request to ensure that serialization does not break anything
         var serializedSpendResponse3 = spendResponse3.getRepresentation();

--- a/crypto/src/test/java/org/cryptimeleon/incentive/crypto/IncentiveSystemTest.java
+++ b/crypto/src/test/java/org/cryptimeleon/incentive/crypto/IncentiveSystemTest.java
@@ -177,7 +177,8 @@ public class IncentiveSystemTest {
                 new SpendDeductBooleanZkp(
                         new TokenUpdateLeaf("TokenUpdateLeaf", zeros, ignore, ones, negatedSpendAmount),
                         incSys.getPp(), promotionParameters, pkp.getPk()));
-        var deserializedSpendRequest3 = new SpendRequest(serializedSpendRequest3, incSys.getPp(), spendDeductProofSystem, tid3);
+        // using tid as user choice TODO change this once user choice generation is properly implemented, see issue 75
+        var deserializedSpendRequest3 = new SpendRequest(serializedSpendRequest3, incSys.getPp(), spendDeductProofSystem, tid3, tid3);
 
         // provider handles spend request and generates spend response and information required for double-spending protection (which is discarded on the fly, since not needed in this test)
         // using tid as user choice TODO change this once user choice generation is properly implemented, see issue 75

--- a/crypto/src/test/java/org/cryptimeleon/incentive/crypto/proof/spend/SpendHelper.java
+++ b/crypto/src/test/java/org/cryptimeleon/incentive/crypto/proof/spend/SpendHelper.java
@@ -116,7 +116,8 @@ public class SpendHelper {
         /* Enable double-spending-protection by forcing usk and esk becoming public in that case
            If token is used twice in two different transactions, the provider observes (c0,c1), (c0',c1') with gamma!=gamma'
            Hence, the provider can easily retrieve usk and esk (using the Schnorr-trick, computing (c0-c0')/(gamma-gamma') for usk, analogously for esk). */
-        var gamma = Util.hashGamma(zp, dsid, tid, cPre0, cPre1);
+        // using tid as user choice TODO change this once user choice generation is properly implemented, see issue 75
+        var gamma = Util.hashGamma(zp, dsid, tid, cPre0, cPre1, tid);
         var c0 = usk.mul(gamma).add(token.getDoubleSpendRandomness0());
         var c1 = esk.mul(gamma).add(token.getDoubleSpendRandomness1());
 

--- a/services/dsprotectionservice/src/test/java/org/cryptimeleon/incentivesystem/dsprotectionservice/DbSyncIntegrationTest.java
+++ b/services/dsprotectionservice/src/test/java/org/cryptimeleon/incentivesystem/dsprotectionservice/DbSyncIntegrationTest.java
@@ -110,7 +110,7 @@ public class DbSyncIntegrationTest {
      * This comes from the fact that until double-spending behaviour is detected,
      * it is actually not interesting which transaction produced which token.
      */
-    // @Test // TODO see https://github.com/cryptimeleon/incentive-system/issues/75
+    @Test
     void cascadingInvalidationsTest() {
         logger.info("Starting cascading invalidations test.");
 

--- a/services/dsprotectionservice/src/test/java/org/cryptimeleon/incentivesystem/dsprotectionservice/DbSyncIntegrationTest.java
+++ b/services/dsprotectionservice/src/test/java/org/cryptimeleon/incentivesystem/dsprotectionservice/DbSyncIntegrationTest.java
@@ -105,10 +105,12 @@ public class DbSyncIntegrationTest {
      * Syncing transactions into the DB, some of which spend the same token.
      * This should be detected as a double-spending attempt and result in cascading invalidations of transactions.
      * We use the graph from section 6 of the 2019 Updatable Anonymous Credentials paper for testing.
-     * <p>
+     *
      * Double-spending IDs dsid4 and dsid5 are computed during the double-spending detection.
      * This comes from the fact that until double-spending behaviour is detected,
      * it is actually not interesting which transaction produced which token.
+     *
+     * The PRFtoZn images hashedClaim that are used
      */
     @Test
     void cascadingInvalidationsTest() {
@@ -157,7 +159,7 @@ public class DbSyncIntegrationTest {
                 pkp,
                 ukp,
                 new Vector<>(new BigInteger("9")), // initial token holds 10 points, we spend one in every transaction
-                incSys.getPp().getBg().getZn().getUniformlyRandomElement(),
+                incSys.getPp().getBg().getZn().getUniformlyRandomElement(), // random transaction ID
                 legacyZkpTree
         );
 
@@ -168,7 +170,7 @@ public class DbSyncIntegrationTest {
                 pkp,
                 ukp,
                 new Vector<>(new BigInteger("9")), // initial token holds 10 points, we spend one in every transaction
-                incSys.getPp().getBg().getZn().getUniformlyRandomElement(),
+                incSys.getPp().getBg().getZn().getUniformlyRandomElement(), // random transaction ID
                 legacyZkpTree
         );
 
@@ -179,7 +181,7 @@ public class DbSyncIntegrationTest {
                 pkp,
                 ukp,
                 new Vector<>(new BigInteger("8")), // initial token holds 10 points, we spend one in every transaction
-                incSys.getPp().getBg().getZn().getUniformlyRandomElement(),
+                incSys.getPp().getBg().getZn().getUniformlyRandomElement(), // random transaction ID
                 legacyZkpTree
         );
 
@@ -190,7 +192,7 @@ public class DbSyncIntegrationTest {
                 pkp,
                 ukp,
                 new Vector<>(new BigInteger("8")), // initial token holds 10 points, we spend one in every transaction
-                incSys.getPp().getBg().getZn().getUniformlyRandomElement(),
+                incSys.getPp().getBg().getZn().getUniformlyRandomElement(), // random transaction ID
                 legacyZkpTree
         );
 
@@ -201,7 +203,7 @@ public class DbSyncIntegrationTest {
                 pkp,
                 ukp,
                 new Vector<>(new BigInteger("7")), // initial token holds 10 points, we spend one in every transaction
-                incSys.getPp().getBg().getZn().getUniformlyRandomElement(),
+                incSys.getPp().getBg().getZn().getUniformlyRandomElement(), // random transaction ID
                 legacyZkpTree
         );
 

--- a/services/inc/src/main/java/org/cryptimeleon/incentive/services/promotion/PromotionService.java
+++ b/services/inc/src/main/java/org/cryptimeleon/incentive/services/promotion/PromotionService.java
@@ -155,7 +155,8 @@ public class PromotionService {
         FiatShamirProofSystem spendDeductProofSystem = new FiatShamirProofSystem(
                 new SpendDeductBooleanZkp(spendDeductTree, pp, promotion.getPromotionParameters(), providerPublicKey)
         );
-        var spendRequest = new SpendRequest(jsonConverter.deserialize(serializedSpendRequest), pp, spendDeductProofSystem, tid);
+        // using tid as user choice TODO change this once user choice generation is properly implemented, see issue 75
+        var spendRequest = new SpendRequest(jsonConverter.deserialize(serializedSpendRequest), pp, spendDeductProofSystem, tid, tid);
 
         // Run deduct
         // using tid as user choice TODO change this once user choice generation is properly implemented, see issue 75

--- a/services/inc/src/main/java/org/cryptimeleon/incentive/services/promotion/PromotionService.java
+++ b/services/inc/src/main/java/org/cryptimeleon/incentive/services/promotion/PromotionService.java
@@ -158,7 +158,8 @@ public class PromotionService {
         var spendRequest = new SpendRequest(jsonConverter.deserialize(serializedSpendRequest), pp, spendDeductProofSystem, tid);
 
         // Run deduct
-        DeductOutput spendProviderOutput = incentiveSystem.generateSpendRequestResponse(promotion.getPromotionParameters(), spendRequest, new ProviderKeyPair(providerSecretKey, providerPublicKey), tid, spendDeductTree);
+        // using tid as user choice TODO change this once user choice generation is properly implemented, see issue 75
+        DeductOutput spendProviderOutput = incentiveSystem.generateSpendRequestResponse(promotion.getPromotionParameters(), spendRequest, new ProviderKeyPair(providerSecretKey, providerPublicKey), tid, spendDeductTree, tid);
 
         // TODO process provider output
 


### PR DESCRIPTION
## Reason for this PR:

- fixed the cascading invalidation test for DB Sync that had an incorrect final token count

## Changes in this PR:

- changed the way that challenge generator gamma and provider share esk_prov are computed in IncentiveSystem.generateSpendRequestResponse: userChoice, tid, dsid added

## Checklist:

Select whatever applies:

- [x] Test written
- [x] Code Properly Formatted
- [x] Documented
- [ ] Changelog updated

