### PR TITLE
Feature/offline dsp taks queue

### DIFF
--- a/android/app/src/main/java/org/cryptimeleon/incentive/app/data/CryptoRepository.kt
+++ b/android/app/src/main/java/org/cryptimeleon/incentive/app/data/CryptoRepository.kt
@@ -68,7 +68,7 @@ class CryptoRepository(
         val generateIssueJoinOutput =
             incentiveSystem.generateJoinRequest(providerPublicKey, userKeyPair)
         val joinResponse = cryptoApiService.runIssueJoin(
-            jsonConverter.serialize(generateIssueJoinOutput.getJoinRequest().representation),
+            jsonConverter.serialize(generateIssueJoinOutput.joinRequest.representation),
             promotionParameters.promotionId.toString()
         )
 

--- a/android/app/src/main/java/org/cryptimeleon/incentive/app/data/network/DosApiService.kt
+++ b/android/app/src/main/java/org/cryptimeleon/incentive/app/data/network/DosApiService.kt
@@ -1,0 +1,9 @@
+package org.cryptimeleon.incentive.app.data.network
+
+import retrofit2.Response
+import retrofit2.http.GET
+
+interface DosApiService {
+    @GET("dos/short-duration")
+    suspend fun launchShortDosAttack(): Response<Unit>
+}

--- a/android/app/src/main/java/org/cryptimeleon/incentive/app/di/HiltModules.kt
+++ b/android/app/src/main/java/org/cryptimeleon/incentive/app/di/HiltModules.kt
@@ -22,6 +22,7 @@ import org.cryptimeleon.incentive.app.data.database.crypto.CryptoDatabase
 import org.cryptimeleon.incentive.app.data.database.promotion.PromotionDatabase
 import org.cryptimeleon.incentive.app.data.network.BasketApiService
 import org.cryptimeleon.incentive.app.data.network.CryptoApiService
+import org.cryptimeleon.incentive.app.data.network.DosApiService
 import org.cryptimeleon.incentive.app.data.network.InfoApiService
 import org.cryptimeleon.incentive.app.data.network.PromotionApiService
 import org.cryptimeleon.incentive.app.domain.IBasketRepository
@@ -76,6 +77,14 @@ class HiltApiModule {
             .baseUrl(PROMOTION_BASE_URL)
             .build()
             .create(PromotionApiService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideDosApiService(): DosApiService =
+        Retrofit.Builder()
+            .baseUrl(PROMOTION_BASE_URL)
+            .build()
+            .create(DosApiService::class.java)
 
     @Singleton
     @Provides

--- a/android/app/src/main/java/org/cryptimeleon/incentive/app/ui/attacker/AttackerUi.kt
+++ b/android/app/src/main/java/org/cryptimeleon/incentive/app/ui/attacker/AttackerUi.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -74,8 +75,9 @@ fun AttackerUi(onUpClicked: () -> Unit) {
         // We apply the contentPadding passed to us from the Scaffold
         AttackerUi(
             doubleSpendingAttackEnabled.discardUpdatedToken,
+            Modifier.padding(contentPadding),
             viewModel::setDiscardUpdatedToken,
-            Modifier.padding(contentPadding)
+            viewModel::launchShortDosAttack
         )
     }
 }
@@ -83,8 +85,9 @@ fun AttackerUi(onUpClicked: () -> Unit) {
 @Composable
 private fun AttackerUi(
     doubleSpendingAttackEnabled: Boolean,
+    modifier: Modifier = Modifier,
     setDiscardEnabled: (Boolean) -> Unit = {},
-    modifier: Modifier = Modifier
+    launchDosAttack: () -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -120,6 +123,9 @@ private fun AttackerUi(
             Switch(checked = doubleSpendingAttackEnabled, onCheckedChange = setDiscardEnabled)
         }
         DoubleSpendingProtectionText(Modifier.padding(bottom = 32.dp))
+        Button(onClick = launchDosAttack, modifier = Modifier.fillMaxWidth()) {
+            Text("Short DoS Attack")
+        }
     }
 }
 

--- a/android/app/src/main/java/org/cryptimeleon/incentive/app/ui/attacker/AttackerViewModel.kt
+++ b/android/app/src/main/java/org/cryptimeleon/incentive/app/ui/attacker/AttackerViewModel.kt
@@ -6,13 +6,16 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
+import org.cryptimeleon.incentive.app.data.network.DosApiService
 import org.cryptimeleon.incentive.app.domain.IPreferencesRepository
 import org.cryptimeleon.incentive.app.domain.model.DoubleSpendingPreferences
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class AttackerViewModel @Inject constructor(
     private val preferencesRepository: IPreferencesRepository,
+    private val dosApiService: DosApiService,
     application: Application
 ) :
     AndroidViewModel(application) {
@@ -22,6 +25,13 @@ class AttackerViewModel @Inject constructor(
     fun setDiscardUpdatedToken(discardToken: Boolean) {
         viewModelScope.launch {
             preferencesRepository.updateDiscardUpdatedToken(discardToken)
+        }
+    }
+
+    fun launchShortDosAttack() {
+        viewModelScope.launch {
+            dosApiService.launchShortDosAttack()
+            Timber.i("short dos")
         }
     }
 }

--- a/services/client/src/main/java/org/cryptimeleon/incentive/client/DSProtectionClient.java
+++ b/services/client/src/main/java/org/cryptimeleon/incentive/client/DSProtectionClient.java
@@ -8,6 +8,7 @@ import org.cryptimeleon.math.structures.groups.GroupElement;
 import org.cryptimeleon.math.structures.rings.zn.Zn;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -55,6 +56,7 @@ public class DSProtectionClient {
                 .header("promotion-id", serializedPromotionId)
                 .header("userchoice", userChoice)
                 .retrieve()
+                .onStatus(httpStatus -> httpStatus != HttpStatus.OK, clientResponse -> Mono.just(new RuntimeException(clientResponse.toString())))
                 .bodyToMono(String.class);
 
         // return response
@@ -70,6 +72,7 @@ public class DSProtectionClient {
         Mono<String> response = this.dsProtectionClient.post()
                 .uri(uriBuilder -> uriBuilder.path(CLEAR_DB_PATH).build())
                 .retrieve()
+                .onStatus(httpStatus -> httpStatus != HttpStatus.OK, clientResponse -> Mono.just(new RuntimeException(clientResponse.toString())))
                 .bodyToMono(String.class);
 
         return response.block();

--- a/services/client/src/main/java/org/cryptimeleon/incentive/client/DSProtectionClient.java
+++ b/services/client/src/main/java/org/cryptimeleon/incentive/client/DSProtectionClient.java
@@ -56,7 +56,6 @@ public class DSProtectionClient {
                 .header("promotion-id", serializedPromotionId)
                 .header("userchoice", userChoice)
                 .retrieve()
-                .onStatus(httpStatus -> httpStatus != HttpStatus.OK, clientResponse -> Mono.just(new RuntimeException(clientResponse.toString())))
                 .bodyToMono(String.class);
 
         // return response
@@ -72,7 +71,6 @@ public class DSProtectionClient {
         Mono<String> response = this.dsProtectionClient.post()
                 .uri(uriBuilder -> uriBuilder.path(CLEAR_DB_PATH).build())
                 .retrieve()
-                .onStatus(httpStatus -> httpStatus != HttpStatus.OK, clientResponse -> Mono.just(new RuntimeException(clientResponse.toString())))
                 .bodyToMono(String.class);
 
         return response.block();

--- a/services/client/src/test/java/org/cryptimeleon/incentive/client/integrationtest/DsProtectionServiceIntegrationTest.java
+++ b/services/client/src/test/java/org/cryptimeleon/incentive/client/integrationtest/DsProtectionServiceIntegrationTest.java
@@ -43,7 +43,7 @@ public class DsProtectionServiceIntegrationTest extends TransactionTestPreparati
      * and checks afterwards whether it was correctly recorded as a transaction in the database.
      */
     @Test
-    public void honestTransactionTest() {
+    public void honestTransactionTest() throws InterruptedException {
         log.info("Started honest transaction integration test.");
 
         log.info("Generate token and basket.");
@@ -53,6 +53,8 @@ public class DsProtectionServiceIntegrationTest extends TransactionTestPreparati
 
         log.info("Spend-Deduct protocol running...");
         TransactionIdentifier occuredTaId = runSpendDeductWorkflow(token, basketId);
+
+        Thread.sleep(2500);
 
         log.info("Done.");
         log.info("Query recorded transaction from database.");
@@ -74,7 +76,7 @@ public class DsProtectionServiceIntegrationTest extends TransactionTestPreparati
      * then checks whether second transaction was recorded as invalid in database.
      */
     @Test
-    public void doubleSpendingTest() {
+    public void doubleSpendingTest() throws InterruptedException {
         log.info("Started double-spending integration test.");
 
         log.info("Generate token to be double-spended and baskets.");
@@ -90,6 +92,8 @@ public class DsProtectionServiceIntegrationTest extends TransactionTestPreparati
         log.info("Double-spending Spend-Deduct execution running...");
         TransactionIdentifier occuredTaId2 = runSpendDeductWorkflow(token, basketId2);
         log.info("Done.");
+
+        Thread.sleep(2500);
 
         log.info("Query recorded transactions from database.");
         String serializedOccuredTaRepr1 = dsProtectionClient.getTransaction(occuredTaId1);

--- a/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/DosService.java
+++ b/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/DosService.java
@@ -1,0 +1,41 @@
+package org.cryptimeleon.incentive.services.incentive;
+
+import org.cryptimeleon.incentive.services.incentive.repository.ScheduledOfflineDSPRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Service
+public class DosService {
+
+    private final ScheduledOfflineDSPRepository offlineDSPRepository;
+
+    @Autowired
+    public DosService(ScheduledOfflineDSPRepository offlineDSPRepository) {
+        this.offlineDSPRepository = offlineDSPRepository;
+    }
+
+    public void addShortWaitPeriod() {
+        offlineDSPRepository.addShortWaitPeriod();
+    }
+
+    public void addLongWaitPeriod() {
+        offlineDSPRepository.addLongWaitPeriod();
+    }
+
+    public void removeAllWaitPeriod() {
+        offlineDSPRepository.removeAllWaitPeriod();
+    }
+
+    public long getRemainingOfflineTimeSeconds() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime waitUntil = offlineDSPRepository.getWaitUntil();
+        if (waitUntil.isAfter(now)) {
+            return Duration.between(now, waitUntil).toSeconds();
+        } else {
+            return 0;
+        }
+    }
+}

--- a/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/IncentiveApplication.java
+++ b/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/IncentiveApplication.java
@@ -35,5 +35,7 @@ public class IncentiveApplication {
     }
 
     @Bean
-    DSProtectionClient dsProtectionClient() { return new DSProtectionClient(dsProtectionServiceUrl); }
+    DSProtectionClient dsProtectionClient() {
+        return new DSProtectionClient(dsProtectionServiceUrl);
+    }
 }

--- a/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/IncentiveController.java
+++ b/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/IncentiveController.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 public class IncentiveController {
 
     private final IncentiveService incentiveService;
+    private final DosService dosService;
 
     @Value("${incentive-service.provider-secret}")
     private String providerSecret;
@@ -101,6 +102,27 @@ public class IncentiveController {
             @RequestHeader(name = "basket-id") UUID basketId
     ) {
         return new ResponseEntity<>(incentiveService.retrieveBulkResults(basketId), HttpStatus.OK);
+    }
+
+
+    @GetMapping("/dos/short-duration")
+    public void shortDos() {
+            dosService.addShortWaitPeriod();
+    }
+
+    @GetMapping("/dos/long-duration")
+    public void longDos() {
+        dosService.addLongWaitPeriod();
+    }
+
+    @GetMapping("/dos/stop")
+    public void stopDos() {
+        dosService.removeAllWaitPeriod();
+    }
+
+    @GetMapping("/dos/remaining-offline-time")
+    public long remainingOfflineTimeSeconds() {
+        return dosService.getRemainingOfflineTimeSeconds();
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/IncentiveController.java
+++ b/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/IncentiveController.java
@@ -37,6 +37,7 @@ public class IncentiveController {
 
         log.info("Provider secret: {}", providerSecret);
     }
+
     /**
      * Endpoint for alive testing etc.
      */
@@ -107,7 +108,7 @@ public class IncentiveController {
 
     @GetMapping("/dos/short-duration")
     public void shortDos() {
-            dosService.addShortWaitPeriod();
+        dosService.addShortWaitPeriod();
     }
 
     @GetMapping("/dos/long-duration")

--- a/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/IncentiveService.java
+++ b/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/IncentiveService.java
@@ -38,11 +38,11 @@ import java.util.stream.Collectors;
 public class IncentiveService {
     private final JSONConverter jsonConverter = new JSONConverter();
 
-    private CryptoRepository cryptoRepository;
-    private PromotionRepository promotionRepository;
-    private BasketRepository basketRepository;
-    private TokenUpdateResultRepository tokenUpdateResultRepository;
-    private OfflineDSPRepository offlineDspRepository;
+    private final CryptoRepository cryptoRepository;
+    private final PromotionRepository promotionRepository;
+    private final BasketRepository basketRepository;
+    private final TokenUpdateResultRepository tokenUpdateResultRepository;
+    private final OfflineDSPRepository offlineDspRepository;
 
     @Autowired
     private IncentiveService(

--- a/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/SpringConfig.java
+++ b/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/SpringConfig.java
@@ -1,0 +1,9 @@
+package org.cryptimeleon.incentive.services.incentive;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SpringConfig {
+}

--- a/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/repository/BasketRepository.java
+++ b/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/repository/BasketRepository.java
@@ -28,7 +28,12 @@ public class BasketRepository {
     @Value("${basket-service.redeem-secret}")
     private String redeemSecret;
 
-    private BasketClient basketClient;
+    private final BasketClient basketClient;
+
+    @Autowired
+    public BasketRepository(BasketClient basketClient) {
+        this.basketClient = basketClient;
+    }
 
     @PostConstruct
     public void validateValue() {
@@ -36,11 +41,6 @@ public class BasketRepository {
             throw new IllegalArgumentException("Redeem secret is not set!");
         }
         log.info("redeem secret: {}", redeemSecret);
-    }
-
-    @Autowired
-    public BasketRepository(BasketClient basketClient) {
-        this.basketClient = basketClient;
     }
 
     public BasketDto getBasketDto(UUID basketId) {

--- a/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/repository/CryptoRepository.java
+++ b/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/repository/CryptoRepository.java
@@ -44,7 +44,7 @@ public class CryptoRepository {
     private String sharedSecret; // used to authenticate the request for the provider secret key (set via environment variable)
 
     // Will be set via dependency injection
-    private InfoClient infoClient;
+    private final InfoClient infoClient;
 
     @Autowired
     private CryptoRepository(InfoClient infoClient) {

--- a/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/repository/CyclingScheduler.java
+++ b/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/repository/CyclingScheduler.java
@@ -1,0 +1,13 @@
+package org.cryptimeleon.incentive.services.incentive.repository;
+
+import java.time.LocalDateTime;
+
+public interface CyclingScheduler {
+    void addShortWaitPeriod();
+
+    void addLongWaitPeriod();
+
+    void removeAllWaitPeriod();
+
+    LocalDateTime getWaitUntil();
+}

--- a/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/repository/DbSyncTask.java
+++ b/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/repository/DbSyncTask.java
@@ -1,11 +1,16 @@
 package org.cryptimeleon.incentive.services.incentive.repository;
 
+import lombok.Value;
 import org.cryptimeleon.incentive.crypto.model.DeductOutput;
 import org.cryptimeleon.incentive.crypto.model.SpendRequest;
 import org.cryptimeleon.math.structures.rings.zn.Zn;
 
 import java.math.BigInteger;
 
-public interface OfflineDSPRepository {
-    void addToDbSyncQueue(BigInteger promotionId, Zn.ZnElement tid, SpendRequest spendRequest, DeductOutput spendProviderOutput);
+@Value
+class DbSyncTask {
+    BigInteger promotionId;
+    Zn.ZnElement tid;
+    SpendRequest spendRequest;
+    DeductOutput deductOutput;
 }

--- a/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/repository/OfflineDSPRepository.java
+++ b/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/repository/OfflineDSPRepository.java
@@ -1,0 +1,95 @@
+package org.cryptimeleon.incentive.services.incentive.repository;
+
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.cryptimeleon.incentive.client.DSProtectionClient;
+import org.cryptimeleon.incentive.crypto.model.DeductOutput;
+import org.cryptimeleon.incentive.crypto.model.SpendRequest;
+import org.cryptimeleon.math.structures.rings.zn.Zn;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigInteger;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+@Slf4j
+@Repository
+public class OfflineDSPRepository {
+    private static final int DBSYNC_QUEUE_CYCLE_DELAY = 2000;
+    private static final int SHORT_WAIT_PERIOD_SECONDS = 30;
+    private static final int LONG_WAIT_PERIOD_SECONDS = 3600;
+
+    private final List<DbSyncTask> taskQueue = Collections.synchronizedList(new ArrayList<>());
+    private LocalDateTime waitUntil = LocalDateTime.now().plus(Duration.ofSeconds(5));
+
+    private DSProtectionClient dsProtectionClient; // object handling the connectivity to the double-spending protection database
+
+    @Autowired
+    public OfflineDSPRepository(DSProtectionClient dsProtectionClient) {
+        this.dsProtectionClient = dsProtectionClient;
+    }
+
+    public void addToDbSyncQueue(BigInteger promotionId, Zn.ZnElement tid, SpendRequest spendRequest, DeductOutput spendProviderOutput) {
+        DbSyncTask dbSyncTask = new DbSyncTask(promotionId, tid, spendRequest, spendProviderOutput);
+        synchronized (taskQueue) {
+            taskQueue.add(dbSyncTask);
+        }
+    }
+
+    public void addShortWaitPeriod() {
+        waitUntil = LocalDateTime.now().plus(Duration.ofSeconds(SHORT_WAIT_PERIOD_SECONDS));
+    }
+
+    public void addLongWaitPeriod() {
+        waitUntil = LocalDateTime.now().plus(Duration.ofSeconds(LONG_WAIT_PERIOD_SECONDS));
+    }
+
+    public void removeAllWaitPeriod() {
+        waitUntil = LocalDateTime.now().minus(Duration.ofSeconds(1));
+    }
+
+    @Scheduled(fixedDelay = DBSYNC_QUEUE_CYCLE_DELAY)
+    private void scheduleFixedDelayTask() {
+        LocalDateTime now = LocalDateTime.now();
+        if (now.isAfter(waitUntil)) {
+            log.debug("Executing all tasks in queue" + waitUntil.format(DateTimeFormatter.ISO_LOCAL_DATE));
+            synchronized (taskQueue) {
+                // TODO make this a batch operation and let dsp service handle the collection of transaction?
+                Iterator<DbSyncTask> i = taskQueue.listIterator();
+                while (i.hasNext()) {
+                    DbSyncTask task = i.next();
+                    triggerDbSync(task.getPromotionId(), task.getTid(), task.getSpendRequest(), task.getDeductOutput());
+                    i.remove();
+                }
+            }
+        } else {
+            log.info("Waiting until " + waitUntil.format(DateTimeFormatter.ISO_LOCAL_DATE));
+        }
+    }
+
+    private void triggerDbSync(BigInteger promotionId, Zn.ZnElement tid, SpendRequest spendRequest, DeductOutput spendProviderOutput) {
+        dsProtectionClient.dbSync(
+                tid,
+                spendRequest.getDsid(),
+                spendProviderOutput.getDstag(),
+                promotionId,
+                tid.toString() // TODO change this once user choice generation is properly implemented
+        );
+    }
+
+}
+
+@Value
+class DbSyncTask {
+    BigInteger promotionId;
+    Zn.ZnElement tid;
+    SpendRequest spendRequest;
+    DeductOutput deductOutput;
+}

--- a/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/repository/ScheduledOfflineDSPRepository.java
+++ b/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/repository/ScheduledOfflineDSPRepository.java
@@ -22,7 +22,7 @@ import java.util.List;
 @Slf4j
 @Repository
 public class ScheduledOfflineDSPRepository implements OfflineDSPRepository, CyclingScheduler {
-    private static final int DBSYNC_QUEUE_CYCLE_DELAY = 2000;
+    private static final int DB_SYNC_QUEUE_CYCLE_DELAY = 2000;
     private static final int SHORT_WAIT_PERIOD_SECONDS = 30;
     private static final int LONG_WAIT_PERIOD_SECONDS = 3600;
 
@@ -60,7 +60,7 @@ public class ScheduledOfflineDSPRepository implements OfflineDSPRepository, Cycl
         waitUntil = LocalDateTime.now().minus(Duration.ofSeconds(1));
     }
 
-    @Scheduled(fixedDelay = DBSYNC_QUEUE_CYCLE_DELAY)
+    @Scheduled(fixedDelay = DB_SYNC_QUEUE_CYCLE_DELAY)
     private void scheduleFixedDelayTask() {
         LocalDateTime now = LocalDateTime.now();
         if (now.isAfter(waitUntil)) {
@@ -88,6 +88,4 @@ public class ScheduledOfflineDSPRepository implements OfflineDSPRepository, Cycl
                 tid.toString() // TODO change this once user choice generation is properly implemented
         );
     }
-
 }
-

--- a/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/repository/ScheduledOfflineDSPRepository.java
+++ b/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/repository/ScheduledOfflineDSPRepository.java
@@ -1,7 +1,6 @@
 package org.cryptimeleon.incentive.services.incentive.repository;
 
 import lombok.Getter;
-import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.cryptimeleon.incentive.client.DSProtectionClient;
 import org.cryptimeleon.incentive.crypto.model.DeductOutput;

--- a/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/repository/ScheduledOfflineDSPRepository.java
+++ b/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/repository/ScheduledOfflineDSPRepository.java
@@ -1,0 +1,94 @@
+package org.cryptimeleon.incentive.services.incentive.repository;
+
+import lombok.Getter;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.cryptimeleon.incentive.client.DSProtectionClient;
+import org.cryptimeleon.incentive.crypto.model.DeductOutput;
+import org.cryptimeleon.incentive.crypto.model.SpendRequest;
+import org.cryptimeleon.math.structures.rings.zn.Zn;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigInteger;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+@Slf4j
+@Repository
+public class ScheduledOfflineDSPRepository implements OfflineDSPRepository, CyclingScheduler {
+    private static final int DBSYNC_QUEUE_CYCLE_DELAY = 2000;
+    private static final int SHORT_WAIT_PERIOD_SECONDS = 30;
+    private static final int LONG_WAIT_PERIOD_SECONDS = 3600;
+
+    private final DSProtectionClient dsProtectionClient; // object handling the connectivity to the double-spending protection database
+    private final List<DbSyncTask> taskQueue = Collections.synchronizedList(new ArrayList<>());
+
+    @Getter
+    private LocalDateTime waitUntil = LocalDateTime.now().plus(Duration.ofSeconds(5));
+
+    @Autowired
+    public ScheduledOfflineDSPRepository(DSProtectionClient dsProtectionClient) {
+        this.dsProtectionClient = dsProtectionClient;
+    }
+
+    @Override
+    public void addToDbSyncQueue(BigInteger promotionId, Zn.ZnElement tid, SpendRequest spendRequest, DeductOutput spendProviderOutput) {
+        DbSyncTask dbSyncTask = new DbSyncTask(promotionId, tid, spendRequest, spendProviderOutput);
+        synchronized (taskQueue) {
+            taskQueue.add(dbSyncTask);
+        }
+    }
+
+    @Override
+    public void addShortWaitPeriod() {
+        waitUntil = LocalDateTime.now().plus(Duration.ofSeconds(SHORT_WAIT_PERIOD_SECONDS));
+    }
+
+    @Override
+    public void addLongWaitPeriod() {
+        waitUntil = LocalDateTime.now().plus(Duration.ofSeconds(LONG_WAIT_PERIOD_SECONDS));
+    }
+
+    @Override
+    public void removeAllWaitPeriod() {
+        waitUntil = LocalDateTime.now().minus(Duration.ofSeconds(1));
+    }
+
+    @Scheduled(fixedDelay = DBSYNC_QUEUE_CYCLE_DELAY)
+    private void scheduleFixedDelayTask() {
+        LocalDateTime now = LocalDateTime.now();
+        if (now.isAfter(waitUntil)) {
+            log.info("Executing all tasks in queue");
+            synchronized (taskQueue) {
+                // TODO make this a batch operation and let dsp service handle the collection of transaction?
+                Iterator<DbSyncTask> i = taskQueue.listIterator();
+                while (i.hasNext()) {
+                    DbSyncTask task = i.next();
+                    triggerDbSync(task.getPromotionId(), task.getTid(), task.getSpendRequest(), task.getDeductOutput());
+                    i.remove();
+                }
+            }
+        } else {
+            log.info("Waiting until " + waitUntil.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        }
+    }
+
+    private void triggerDbSync(BigInteger promotionId, Zn.ZnElement tid, SpendRequest spendRequest, DeductOutput spendProviderOutput) {
+        dsProtectionClient.dbSync(
+                tid,
+                spendRequest.getDsid(),
+                spendProviderOutput.getDstag(),
+                promotionId,
+                tid.toString() // TODO change this once user choice generation is properly implemented
+        );
+    }
+
+}
+

--- a/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/repository/TokenUpdateResultRepository.java
+++ b/services/incentive/src/main/java/org/cryptimeleon/incentive/services/incentive/repository/TokenUpdateResultRepository.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 // This is the cache for results of token updates that are held back util the user pays the basket.
 @Repository
 public class TokenUpdateResultRepository {
-    private Map<UUID, Map<BigInteger, TokenUpdateResult>> tokenUpdateResultMap;
+    private final Map<UUID, Map<BigInteger, TokenUpdateResult>> tokenUpdateResultMap;
 
     public TokenUpdateResultRepository() {
         tokenUpdateResultMap = new HashMap<>();


### PR DESCRIPTION
## Reason for this PR:

- The incentive service now enqueues all dbsync tasks in a queue and periodically checks whether to send these
- Users can add a DoS time amount of either 30s or 1h and reset this time to delay the above execution
- Does **not** include the online rejection, will add that in a second step/branch
- Add button in app's attacker view to launch short dos attack